### PR TITLE
CBP-4373 Updated the base image and removed wget due to an un-patched vulnerability CVE-2024-38428

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,1 @@
-FROM alpine/helm:3.15.2
+FROM alpine/helm:3.16.1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,3 @@
 FROM alpine/helm:3.16.1
+## Removed wget due Vulnerability ##
+RUN apk del wget


### PR DESCRIPTION
updated the base image and removed wget due to an un-patched vulnerability 

- [CVE-2024-38428](https://nvd.nist.gov/vuln/detail/CVE-2024-38428)
