### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
-FROM alpine/helm:3.16.1
+FROM alpine/helm:3.17.0
 ## Removed wget due Vulnerability ##
 RUN apk del wget


### PR DESCRIPTION
Updated Helm base image to the latest release to address  GHSA-v778-237x-gjrc - golang.org/x/crypto-v0.26.0(go)