### PR TITLE
CBP-14018 - Helm Version Upgrade

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine/helm:3.17.0
+FROM alpine/helm:3.18.2
 # Update Packages to address Security Issues 
 RUN set -eux; \
     apk upgrade --no-cache apk-tools>2.14.6-r3 \


### PR DESCRIPTION
The Vulnerability **CBP-14018** is related to **https://github.com/cloudbees-io/helm-uninstall** repo, which is using helm 3.17.0 currently **https://github.com/cloudbees-io/helm-uninstall/blob/main/Dockerfile**.

Helm 3.17.0 uses go 1.23.0 and Helm 3.18.2 uses go 1.24.0.

**https://github.com/helm/helm/blob/v3.17.0/go.mod**
**https://github.com/helm/helm/blob/v3.18.2/go.mod**

As per the mitigation suggested in the security ticket, we should upgrade to 1.23.8,1.24.2.

Since latest Helm 3.18.2 is using Go 1.24.0, we can upgrade our repo to use helm 3.18.2.