### PR TITLE
CBP-23966: upgrade pcre2 to 10.46-r0 (CVE-2025-58050)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,4 +12,5 @@ RUN set -eux; \
                            libcurl \
                            curl \
                            musl-utils \
-                           yq-go
+                           yq-go; \
+    apk upgrade --no-cache pcre2


### PR DESCRIPTION
**Check old and new versions as shown below, as per mitigation in the jira ticket**

**Ticket => https://cloudbees.atlassian.net/browse/CBP-23966**

<img width="1727" height="523" alt="image" src="https://github.com/user-attachments/assets/5b9d0d28-0e34-49a4-a60e-f0c943ec73ba" />
