### PR TITLE
CBP-22647: Fixing security ticket to upgrade version of libexpat

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,4 +13,5 @@ RUN set -eux; \
                            curl \
                            musl-utils \
                            yq-go; \
-    apk upgrade --no-cache pcre2
+    apk upgrade --no-cache pcre2; \
+    apk add --no-cache libexpat=2.7.3-r0


### PR DESCRIPTION
CBP-22647: Fixing security ticket to upgrade version of libexpat > 2.7.2