### PR TITLE
[CBP-52689] bump helm image to 3.21.3 (latest 3.x) to fix  GHSA-5cgq-…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine/helm:3.21.2
+FROM alpine/helm:3.21.3
 # Update Packages to address Security Issues
 RUN set -eux; \
     apk upgrade --no-cache apk-tools \


### PR DESCRIPTION
…3rg8-m6cv in helm binary